### PR TITLE
test.sh improvements

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,13 @@ run() {
     "$@"
 }
 
+# Some distros support multiple installed versions of PostgreSQL
+if ! command -v initdb 2>/dev/null; then
+    for dir in /usr/lib/postgresql/*; do
+	export PATH="${dir}/bin:${PATH}"
+    done
+fi
+
 if ! command -v initdb 2>/dev/null; then
     echo "No PostgreSQL utilities in PATH" >&2
     exit 1

--- a/test.sh
+++ b/test.sh
@@ -38,14 +38,14 @@ for file in schema.sql stats.sql; do
     run ${PSQL} -f "$file"
 done
 
-if [ "$1" = 'develop' ]; then
-    run psql -h "${WORKDIR}" -d postgres
-else
-    for file in tests/plpgunit/install/1.install-unit-test.sql tests/*.sql
-    do
-	run ${PSQL} -f "$file"
-    done
+for file in tests/plpgunit/install/1.install-unit-test.sql tests/*.sql; do
+    run ${PSQL} -f "$file"
+done
 
-    run ${PSQL} -c 'SELECT * FROM unit_tests.begin();' | tee "${WORKDIR}/log"
+run ${PSQL} -c 'SELECT * FROM unit_tests.begin();' | tee "${WORKDIR}/log"
+
+if [ "$1" != 'develop' ]; then
     grep -q 'Failed tests *: 0.' "${WORKDIR}/log"
+else
+    run psql -h "${WORKDIR}" -d postgres
 fi

--- a/test.sh
+++ b/test.sh
@@ -47,5 +47,9 @@ run ${PSQL} -c 'SELECT * FROM unit_tests.begin();' | tee "${WORKDIR}/log"
 if [ "$1" != 'develop' ]; then
     grep -q 'Failed tests *: 0.' "${WORKDIR}/log"
 else
-    run psql -h "${WORKDIR}" -d postgres
+    if command -v pgcli >/dev/null; then
+	run pgcli -h "${WORKDIR}" -d postgres
+    else
+	run psql -h "${WORKDIR}" -d postgres
+    fi
 fi


### PR DESCRIPTION
- [x] Tests and `make develop` now work out-of-the-box on Debian and derivatives.
- [x] In `make develop`, the DB is pre-populated with test data.
- [x] In `make develop`, `pgcli` is used as a PostgreSQL client when available.