### PR TITLE
passwd: Remove the 'homedir' column

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,9 +152,9 @@ in `crypt(3)` format.
 Extracting user information is fairly straightforward:
 
 	# Returns (name, passwd, gecos, dir, shell, uid, gid) for a given name or uid, or all
-	getpwnam = SELECT name, '!', data->>'name', homedir, data->>'shell', uid, uid FROM passwd WHERE name = $1
-	getpwuid = SELECT name, '!', data->>'name', homedir, data->>'shell', uid, uid FROM passwd WHERE uid  = $1
-	allusers = SELECT name, '!', data->>'name', homedir, data->>'shell', uid, uid FROM passwd
+	getpwnam = SELECT "name", '!', "data"->>'name', '/home/' || "name", "data"->>'shell', uid, uid FROM passwd WHERE name = $1
+	getpwuid = SELECT "name", '!', "data"->>'name', '/home/' || "name", "data"->>'shell', uid, uid FROM passwd WHERE uid = $1
+	allusers = SELECT "name", '!', "data"->>'name', '/home/' || "name", "data"->>'shell', uid, uid FROM passwd
 
 
 Retrieving group-related data is a bit harder, as there as two kinds of groups:

--- a/schema.sql
+++ b/schema.sql
@@ -28,7 +28,6 @@ CREATE TABLE "passwd" (
     DEFAULT nextval('user_id'),
   "name" username_t UNIQUE NOT NULL,
   "host" text NOT NULL REFERENCES hosts (name),
-  "homedir" text NOT NULL,
   "data" jsonb  -- conforms to the user_data.yaml schema
     CHECK(length(data::text) < 1048576) -- max 1M
 );

--- a/tests/00basic.sql
+++ b/tests/00basic.sql
@@ -58,8 +58,8 @@ DECLARE message test_result;
 DECLARE result boolean;
 DECLARE passwd_name text;
 BEGIN
-    insert into passwd (name, host, "homedir","data") values ('testuser', 'testbox.hashbang.sh', '/home/testuser', '{"ssh_keys": [], "shell": "/sbin/nologin"}'::jsonb);
-    insert into passwd (name, host, "homedir","data") values ('testuser2', 'testbox.hashbang.sh', '/home/testuser2', '{"ssh_keys": [], "shell": "/bin/sh"}'::jsonb) returning name INTO passwd_name;
+    insert into passwd (name, host, "data") values ('testuser', 'testbox.hashbang.sh', '{"ssh_keys": [], "shell": "/sbin/nologin"}'::jsonb);
+    insert into passwd (name, host, "data") values ('testuser2', 'testbox.hashbang.sh', '{"ssh_keys": [], "shell": "/bin/sh"}'::jsonb) returning name INTO passwd_name;
     SELECT * FROM assert.is_equal(passwd_name,'testuser2') INTO message, result;
     IF result = false THEN RETURN message; END IF;
 
@@ -74,8 +74,8 @@ DECLARE message test_result;
 DECLARE result boolean;
 DECLARE passwd_name text;
 BEGIN
-    insert into passwd (name, host, "homedir","data")
-    values ('testadmin', 'fo0.hashbang.sh', '/home/testadmin',
+    insert into passwd (name, host, "data")
+    values ('testadmin', 'fo0.hashbang.sh',
     '{ "name":"Just an admin.", "ssh_keys": [], "shell": "/usr/bin/zsh" }'::jsonb)
     RETURNING uid INTO user_id;
 

--- a/tests/01nss.sql
+++ b/tests/01nss.sql
@@ -17,7 +17,7 @@ DECLARE user_pass  text;
 DECLARE user_shell text;
 DECLARE user_gecos text;
 BEGIN
-    SELECT "name", '!', "data"->>'name', homedir, "data"->>'shell', uid, uid
+    SELECT "name", '!', "data"->>'name', '/home/' || "name", "data"->>'shell', uid, uid
       FROM passwd
      WHERE name = 'testadmin'
       INTO user_name, user_pass, user_gecos, user_home, user_shell, user_uid, user_gid;
@@ -63,7 +63,7 @@ BEGIN
       INTO user_uid;
 
     -- Query for getpwuid
-    SELECT "name", '!', "data"->>'name', homedir, "data"->>'shell', uid, uid
+    SELECT "name", '!', "data"->>'name', '/home/' || "name", "data"->>'shell', uid, uid
       FROM passwd
      WHERE uid = user_uid
       INTO user_name, user_pass, user_gecos, user_home, user_shell, user_uid, user_gid;

--- a/tests/04schemas.sql
+++ b/tests/04schemas.sql
@@ -20,7 +20,7 @@ RETURNS test_result AS $$
 DECLARE message test_result;
 BEGIN
     BEGIN
-        insert into passwd (name, host, "homedir","data") values ('invaliduser', 'testbox.hashbang.sh', '/home/testuser', '{}'::jsonb);
+        insert into passwd (name, host, "data") values ('invaliduser', 'testbox.hashbang.sh', '{}'::jsonb);
     	RETURN assert.fail('Successfully inserted user.');
     EXCEPTION
 	WHEN check_violation THEN


### PR DESCRIPTION
As mentionned in #21, it violates 2 design principles for userdb:
- no data duplication (`homedir` can be computed as `'/home/' || name`);
- store non-relational data in `data`.

Changes effected:
- [x] 'homedir' column removed from passwd.
- [x] Adapt tests that inserted data in 'passwd'.
- [x] Use an expression to compute the homedir in tests that query from passwd.

Thanks a bunch to @mayli, again, for making me notice the issue.