### PR TITLE
json-schemas.py: string.replace is deprecated

### DIFF
--- a/json-schemas.py
+++ b/json-schemas.py
@@ -8,7 +8,7 @@ for name in ('user', 'host'):
     with open("schemas/data_%s.yml" % name, 'r') as schema:
         json_data = json.dumps(yaml.load(schema), indent=4)
         assert("$$" not in json_data)
-        data = string.replace(data, '{data_%s}' % name, json_data)
+        data = data.replace('{data_%s}' % name, json_data)
 
 with open('json-schemas.sql.tmp', 'w') as outfile:
     outfile.write(data)


### PR DESCRIPTION
https://docs.python.org/2/library/string.html#deprecated-string-functions