### PR TITLE
Fix doc links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Please consider the following when submitting contributions:
   - Observe the [Design Requirements].
   - Update the [Design Documentation] whenever designing new features
 	or modifying their implementation.
-  - Follow the [SQL Style Guide].
   - Use Pull Requests for all changes.
   - Pull Requests are only merged when all tests pass **when merged with
 	master**. This is [the “not rocket science” rule] of software.
@@ -64,9 +63,8 @@ Feel free to reach out to us with ideas or to get help contributing. We
 are totally happy with something taking longer to do, if you learn
 something in the process. It is the reason #! exists.
 
-[Design Requirements]:  REQUIREMENTS.md
-[Design Documentation]: DESIGN.md
-[SQL Style Guide]:      STYLEGUIDE.md
+[Design Requirements]:  docs/REQUIREMENTS.md
+[Design Documentation]: docs/DESIGN.md
 [the “not rocket science” rule]: https://graydon2.dreamwidth.org/1597.html
 
 ## Notes ##


### PR DESCRIPTION
Two links weren't updated after their targets moved, and one's target was deleted altogether in commit a7d2001d9c339d0c547b067a7bdb608ef90cfb1a.